### PR TITLE
Fix RadioBoxProps interface name

### DIFF
--- a/src/components/NewTransactionModal/styles.ts
+++ b/src/components/NewTransactionModal/styles.ts
@@ -57,7 +57,7 @@ export const TransactionTypeContainer = styled.div`
 `;
 
 
-interface RadioboxProps {
+interface RadioBoxProps {
     isActive: boolean;
     activeColor: 'green' | 'red';
 }
@@ -67,7 +67,7 @@ const colors = {
     red: '#E52E4D'
 }
 
-export const RadioBox = styled.button<RadioboxProps>`
+export const RadioBox = styled.button<RadioBoxProps>`
   height: 4rem;
   border: 1px solid var(--border);
   border-radius: 0.25rem;


### PR DESCRIPTION
The interface was named _RadioboxProps_ but everywhere on the code the word RadioBox was being written using uppercase letter for B.